### PR TITLE
Add sync HEX view to Disassembly view

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,9 @@ pub struct SystemConfig {
     pub sync_blocks_view: bool,
     #[serde(default = "default_true")]
     pub auto_analyze: bool,
+	#[serde(default = "default_true")]
+	pub sync_hex_dump: bool,
+
 }
 
 fn default_true() -> bool {
@@ -30,6 +33,8 @@ impl Default for SystemConfig {
             theme: "Solarized Dark".to_string(),
             sync_blocks_view: true,
             auto_analyze: true,
+			sync_hex_dump: true,
+
         }
     }
 }

--- a/src/ui/dialog_settings.rs
+++ b/src/ui/dialog_settings.rs
@@ -57,6 +57,14 @@ impl Widget for SettingsDialog {
                     "[ ]"
                 }
             ),
+			            format!(
+                "{} Sync Hex Dump View",
+                if app_state.system_config.sync_hex_dump {
+                    "[X]"
+                } else {
+                    "[ ]"
+                }
+            ),
             format!("Theme: < {} >", app_state.system_config.theme),
         ];
 
@@ -176,7 +184,10 @@ impl Widget for SettingsDialog {
                 } else if self.selected_index == 2 {
                     app_state.system_config.auto_analyze = !app_state.system_config.auto_analyze;
                     let _ = app_state.system_config.save();
-                } else if self.selected_index == 3 {
+				} else if self.selected_index == 3 {
+                    app_state.system_config.sync_hex_dump = !app_state.system_config.sync_hex_dump;
+                    let _ = app_state.system_config.save();
+                } else if self.selected_index == 4 {
                     self.is_selecting_theme = true;
                 }
                 WidgetResult::Handled


### PR DESCRIPTION
Synchronization between Disassembly, HexDump and Charset views

Added bidirectional cursor synchronization between all view combinations
Added sync_hex_dump config option to enable/disable synchronization

Files modified:
src/config.rs - Added sync_hex_dump: bool field to SystemConfig
src/events.rs - Added 6 synchronization blocks in main event loop
src/ui/dialog_settings.rs - Added "Sync Hex Dump View" toggle in settings UI